### PR TITLE
Resolve issue with sending HTML with ActionMailer

### DIFF
--- a/lib/resend/mailer.rb
+++ b/lib/resend/mailer.rb
@@ -21,7 +21,7 @@ module Resend
       params[:cc] = mail[:cc].to_s if mail[:cc].present?
       params[:bcc] = mail[:bcc].to_s if mail[:bcc].present?
       params[:reply_to] = mail[:reply_to].to_s if mail[:reply_to].present?
-      params[:html] = mail.body.decoded
+      params[:html] = mail.html_part.decode_body
 
       resp = @resend_client.send_email(params)
 


### PR DESCRIPTION
Encountered an issue trying to use ActionMailer. Whenever I called `deliver_now!` I received an error:

```
 Resend::ResendError: Missing `html` or `text` field
/Users/willman/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/resend-0.2.1/lib/resend/client.rb:59:in `handle_error!'
/Users/willman/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/resend-0.2.1/lib/resend/client.rb:34:in `send_email'
/Users/willman/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/resend-0.2.1/lib/resend/mailer.rb:26:in `deliver!'
/Users/willman/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/mail-2.7.1/lib/mail/message.rb:276:in `deliver!'
/Users/willman/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/actionmailer-7.0.1/lib/action_mailer/message_delivery.rb:109:in `block in deliver_now!'
/Users/willman/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/actionmailer-7.0.1/lib/action_mailer/rescuable.rb:17:in `handle_exceptions'
/Users/willman/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/actionmailer-7.0.1/lib/action_mailer/message_delivery.rb:108:in `deliver_now!'
```

It's resolved with this change